### PR TITLE
Remove todo-tree extension and add ALPHANUM_SCOPE_REGEX

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,7 +13,6 @@
 		"alefragnani.project-manager",
 		"pkief.material-icon-theme",
 		"aaron-bond.better-comments",
-		"gruntfuggly.todo-tree",
 		"piotrpalarz.vscode-gitignore-generator",
 		"timonwong.shellcheck",
 		"davidanson.vscode-markdownlint",

--- a/src/potato_util/constants/_regex.py
+++ b/src/potato_util/constants/_regex.py
@@ -8,6 +8,7 @@ ALPHANUM_SPACE_REGEX = r"^[0-9a-zA-Z ]+$"
 ALPHANUM_HYPHEN_REGEX = r"^[0-9a-zA-Z_\-]+$"
 ALPHANUM_HOST_REGEX = r"^[0-9a-zA-Z_\-.]+$"
 ALPHANUM_EXTEND_REGEX = r"^[0-9a-zA-Z_\-. ]+$"
+ALPHANUM_SCOPE_REGEX = r"^[0-9a-zA-Z_\-.:\*]+$"
 ALPHANUM_PATH_REGEX = r"^[0-9a-zA-Z_\-. \\\/]+$"
 
 ALPHANUM_KR_MN_REGEX = r"^[0-9a-zA-Z가-힣А-яҮүӨөЁё]+$"
@@ -50,6 +51,7 @@ __all__ = [
     "ALPHANUM_HYPHEN_REGEX",
     "ALPHANUM_HOST_REGEX",
     "ALPHANUM_EXTEND_REGEX",
+    "ALPHANUM_SCOPE_REGEX",
     "ALPHANUM_PATH_REGEX",
     "ALPHANUM_KR_MN_REGEX",
     "ALPHANUM_KR_MN_SPACE_REGEX",


### PR DESCRIPTION
Eliminate the todo-tree extension from recommendations and introduce a new regex for validating alphanumeric characters with scope.